### PR TITLE
Fix: Remove wrong information on jpl download

### DIFF
--- a/src/pages/downloadPlugin.mustache
+++ b/src/pages/downloadPlugin.mustache
@@ -44,8 +44,7 @@
 							If you know what you're doing, you can alternatively
 							<a id='plugin-download-link'>
 								download this plugin's <code>.jpl</code> file
-							</a>. This method of installation, however, will <b>not</b>
-							auto-update the plugin.
+							</a>.
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
Remove wrong information about manual installation.

The plugins can also be updated via the GUI after a manual installation. You will also be notified that an update is available. 

Validated on Windows with the following methods:

- Install via droping the jpl in the plugins folder
- Install via Install from file in the GUI 