### PR TITLE
Plugin website: Fixes #51: Redirect from joplin.github.io to joplinapp.org

### DIFF
--- a/src/runtime/pages/plugin-list/index.ts
+++ b/src/runtime/pages/plugin-list/index.ts
@@ -1,5 +1,8 @@
+import handleRedirects from '../../util/handleRedirects';
 import initializePluginListPage from './initializePluginListPage';
 
 window.addEventListener('DOMContentLoaded', async () => {
 	initializePluginListPage();
 });
+
+handleRedirects();

--- a/src/runtime/pages/plugin/index.ts
+++ b/src/runtime/pages/plugin/index.ts
@@ -1,5 +1,8 @@
+import handleRedirects from '../../util/handleRedirects';
 import initializePluginPage from './initializePluginPage';
 
 window.addEventListener('DOMContentLoaded', async () => {
 	initializePluginPage();
 });
+
+handleRedirects();

--- a/src/runtime/util/handleRedirects.test.ts
+++ b/src/runtime/util/handleRedirects.test.ts
@@ -1,0 +1,26 @@
+import handleRedirects from './handleRedirects';
+
+describe('handleRedirects', () => {
+	test.each([
+		['https://joplin.github.io/website-plugin-discovery/', 'https://joplinapp.org/plugins/'],
+		[
+			'https://joplin.github.io/website-plugin-discovery/plugin/joplin.plugin.alondmnt.time-slip/?from-tab=all',
+			'https://joplinapp.org/plugins/plugin/joplin.plugin.alondmnt.time-slip/?from-tab=all',
+		],
+		[
+			'https://joplinapp.org/plugins/plugin/joplin.plugin.alondmnt.time-slip/?from-tab=all',
+			'https://joplinapp.org/plugins/plugin/joplin.plugin.alondmnt.time-slip/?from-tab=all',
+		],
+		[
+			'https://joplin.github.io/website-plugin-discovery/view-source.html?plugin=joplin.plugin.alondmnt.time-slip?from-tab=all#index.js',
+			'https://joplinapp.org/plugins/view-source.html?plugin=joplin.plugin.alondmnt.time-slip?from-tab=all#index.js',
+		],
+	])(
+		'should redirect from joplin.github.io to joplinapp.org/plugins (case %#)',
+		(redirectFrom, redirectTo) => {
+			globalThis.location = { href: redirectFrom } as Location;
+			handleRedirects();
+			expect(location.href).toBe(redirectTo);
+		},
+	);
+});

--- a/src/runtime/util/handleRedirects.ts
+++ b/src/runtime/util/handleRedirects.ts
@@ -1,5 +1,8 @@
 const handleRedirects = () => {
 	const pageUrl = new URL(location.href);
+
+	// The plugin website was previously hosted at joplin.github.io -- redirect old links
+	// to it's new location:
 	if (pageUrl.host === 'joplin.github.io') {
 		const path = pageUrl.pathname.replace(/^[/]?website-plugin-discovery[/]/, '');
 		location.href = `https://joplinapp.org/plugins/${path}${pageUrl.search}${pageUrl.hash}`;

--- a/src/runtime/util/handleRedirects.ts
+++ b/src/runtime/util/handleRedirects.ts
@@ -1,0 +1,9 @@
+const handleRedirects = () => {
+	const pageUrl = new URL(location.href);
+	if (pageUrl.host === 'joplin.github.io') {
+		const path = pageUrl.pathname.replace(/^[/]?website-plugin-discovery[/]/, '');
+		location.href = `https://joplinapp.org/plugins/${path}${pageUrl.search}${pageUrl.hash}`;
+	}
+};
+
+export default handleRedirects;


### PR DESCRIPTION
# Summary

Fixes #51: Redirects from https://joplin.github.io/website-plugin-discovery/ to https://joplinapp.org/plugins/.

# Testing plan

This pull request includes an automated test. Additionally, it has been tested manually by:
1. Applying a diff to redirect `localhost:8000` to `joplinapp.org`:
    <details>
    
    ```diff
    diff --git a/src/runtime/util/handleRedirects.ts b/src/runtime/util/handleRedirects.ts
    index 613d8c9..5629f73 100644
    --- a/src/runtime/util/handleRedirects.ts
    +++ b/src/runtime/util/handleRedirects.ts
    @@ -1,7 +1,7 @@
     const handleRedirects = () => {
 	    const pageUrl = new URL(location.href);
    -	if (pageUrl.host === 'joplin.github.io') {
    -		const path = pageUrl.pathname.replace(/^[/]?website-plugin-discovery[/]/, '');
    +	if (pageUrl.host === 'localhost:8000') {
    +		const path = pageUrl.pathname.replace(/^[/]?site[/]/, '');
 		    location.href = `https://joplinapp.org/plugins/${path}${pageUrl.search}${pageUrl.hash}`;
 	    }
     };
    ```
    </details>
2. Building the website and serving it at `localhost:8000/site`.
3. Opening `http://localhost:8000/site/plugin/com.whatever.quick-links/?from-tab=home`.
4. Verifying that the browser redirects to `https://joplinapp.org/plugins/plugin/com.whatever.quick-links/?from-tab=home`