### PR TITLE
chore: Update copyright date

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Joplin
+Copyright (c) 2023-2024 Joplin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build/data/getGlobalMarketplaceData.ts
+++ b/build/data/getGlobalMarketplaceData.ts
@@ -10,6 +10,9 @@ const getMarketplaceData = async (config: BuildConfig): Promise<MarketplaceData>
 		allPossibleCategories: await getAllPossibleCategories(plugins),
 		plugins,
 		config,
+		buildInfo: {
+			copyright: `© Joplin 2023 - ${new Date().getFullYear()}`,
+		},
 	};
 };
 

--- a/lib/testData.ts
+++ b/lib/testData.ts
@@ -123,6 +123,9 @@ const testData: MarketplaceData = {
 		distDir: path.join(__dirname, 'site'),
 		site: '/site',
 	},
+	buildInfo: {
+		copyright: 'test',
+	},
 };
 
 export { testPlugin1, testPlugin2, testPlugin3, testPlugin4 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -96,9 +96,14 @@ export interface Category {
 	plugins: JoplinPlugin[];
 }
 
+interface BuildInfo {
+	copyright: string;
+}
+
 // Global data about plugins, categories, etc.
 export interface MarketplaceData {
 	allPossibleCategories: Category[];
 	plugins: GlobalPluginData;
 	config: BuildConfig;
+	buildInfo: BuildInfo;
 }

--- a/src/components/page-footer.mustache
+++ b/src/components/page-footer.mustache
@@ -9,7 +9,7 @@
 	</div>
 
 	<div class="links legal-and-about-links">
-		<div class="copyright">© Joplin 2023 - 2024</div>
+		<div class="copyright">{{buildInfo.copyright}}</div>
 		<a class="link terms-and-conditions" href="{{config.site}}/terms-and-conditions.html">Terms and conditions</a>
 		<a class="link privacy" href="{{config.site}}/privacy-policy.html">Privacy policy</a>
 	</div>

--- a/src/components/page-footer.mustache
+++ b/src/components/page-footer.mustache
@@ -9,7 +9,7 @@
 	</div>
 
 	<div class="links legal-and-about-links">
-		<div class="copyright">© Joplin 2023</div>
+		<div class="copyright">© Joplin 2023 - 2024</div>
 		<a class="link terms-and-conditions" href="{{config.site}}/terms-and-conditions.html">Terms and conditions</a>
 		<a class="link privacy" href="{{config.site}}/privacy-policy.html">Privacy policy</a>
 	</div>


### PR DESCRIPTION
# Summary

Updates the copyright date in `LICENSE` and the page footer.



Resolves #53.