### PR TITLE
chore(build): Attempt to fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-          cache: 'yarn'
       - run: corepack enable
       - run: yarn install
       - run: yarn build-production /website-plugin-discovery


### PR DESCRIPTION
# Summary

This is a follow-up pull request to https://github.com/joplin/website-plugin-discovery/pull/55. With #55, CI still fails with
```
error This project's package.json defines "packageManager": "yarn@4.5.0". However the current global version of Yarn is 1.22.22.

Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
Corepack must currently be enabled by running corepack enable in your terminal. For more information, check out https://yarnpkg.com/corepack.
Error: error This project's package.json defines "packageManager": "yarn@4.5.0". However the current global version of Yarn is 1.22.22.
```

This error comes from before the `corepack enable` step (from within `actions/setup-node@v3`) and thus should be fixed by not requesting that `actions/setup-node@v3` cache `yarn` dependencies.